### PR TITLE
register float and int input options

### DIFF
--- a/src/array_api_jax_compat/_creation_functions.py
+++ b/src/array_api_jax_compat/_creation_functions.py
@@ -40,10 +40,10 @@ T = TypeVar("T")
 
 @dispatcher  # type: ignore[misc]
 def arange(
-    start: jax.Array | jax.core.Tracer,
+    start: jax.Array | jax.core.Tracer | float | int,
     /,
-    stop: jax.Array | None = None,
-    step: jax.Array | int = 1,
+    stop: jax.Array | float | int | None = None,
+    step: jax.Array | float | int = 1,
     *,
     dtype: DType | None = None,
     device: Device | None = None,

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -1,7 +1,9 @@
 """Test with JAX inputs."""
 
 
+import jax.numpy as jnp
 from jax.experimental import array_api as jax_xp
+import pytest
 
 import array_api_jax_compat as xp
 
@@ -38,14 +40,35 @@ def test_pi():
 # Creation functions
 
 
-# def test_arange():
-#     """Test `arange`."""
-#     # TODO: test the start, stop, step, dtype, device arguments
-#     got = xp.arange(3)
-#     expected = jax_xp.arange(3)
+@pytest.mark.parametrize(
+    ("start", "stop", "step"),
+    [
+        # int
+        (3, None, 1),
+        (3, 1, 1),
+        (4, None, 2),
+        (3, 1, 2),
+        # float
+        (3.0, None, 1),
+        (3.0, 1.0, 1),
+        (4.0, None, 2.0),
+        (3.0, 1.0, 2.0),
+        # Array
+        (jnp.array(3), None, 1),
+        (jnp.array(3), jnp.array(1), 1),
+        (jnp.array(4), None, jnp.array(2)),
+        (jnp.array(3), jnp.array(1), jnp.array(2)),
+        # TODO: mixed
+    ],
+)
+def test_arange(start, stop, step):
+    """Test `arange`."""
+    # TODO: test the start, stop, step, dtype, device arguments
+    got = xp.arange(start, stop, step)
+    expected = jax_xp.arange(start, stop, step)
 
-#     assert isinstance(got, jnp.ndarray)
-#     assert jnp.array_equal(got, expected)
+    assert isinstance(got, jnp.ndarray)
+    assert jnp.array_equal(got, expected)
 
 
 # def test_asarray():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -2,8 +2,8 @@
 
 
 import jax.numpy as jnp
-from jax.experimental import array_api as jax_xp
 import pytest
+from jax.experimental import array_api as jax_xp
 
 import array_api_jax_compat as xp
 


### PR DESCRIPTION
`arange` should work on the inputs that works for `jax`.